### PR TITLE
add 'logSkyuxVersion' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All of the following options are required and overridable via the CLI.  For exam
 | `name`                  | `null` |
 | `version`               | `version` property in `package.json` |
 | `skyuxVersion`          | `_requested.spec` in the `package.json` file in `./node_modules/blackbaud-skyux2/` |
+| `logSkyuxVersion`       | `true`  | 
 | `azureStorageAccount`   | `null`  |
 | `azureStorageAccessKey` | `null`  |
 | `azureStorageTableName` | "spa"   |

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -56,15 +56,16 @@ function getSkyuxVersion() {
  * @name getSettings
  * @returns {Object} settings
  */
-function getSettings(argv) {
+function getSettings(argv = {}) {
 
   const packageConfig = getLocalConfig('package.json');
   const skyuxConfig = getLocalConfig('skyuxconfig.json');
+  const logSkyuxVersion = argv.logSkyuxVersion !== 'false' && argv.logSkyuxVersion !== false;
 
   const defaults = {
     name: '',
     version: '',
-    skyuxVersion: getSkyuxVersion(),
+    skyuxVersion: logSkyuxVersion ? getSkyuxVersion() : '',
     packageConfig: packageConfig,
     skyuxConfig: skyuxConfig,
     azureStorageTableName: 'spa'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,6 +45,7 @@ function validate(assets, settings) {
     'name',
     'version',
     'skyuxVersion',
+    'logSkyuxVersion',
     'azureStorageAccount',
     'azureStorageAccessKey',
     'azureStorageTableName'

--- a/test/lib-settings.spec.js
+++ b/test/lib-settings.spec.js
@@ -59,7 +59,7 @@ describe('skyux-deploy lib settings', () => {
     );
   });
 
-  function setupPackageJson(_requested) {
+  function setupPackageJson(_requested, argv) {
     const skyuxInstalledPath = path.join(
       process.cwd(),
       'node_modules',
@@ -81,11 +81,35 @@ describe('skyux-deploy lib settings', () => {
     });
 
     const lib = require('../lib/settings');
-    const settings = lib.getSettings();
+    const settings = lib.getSettings(argv);
 
     expect(logger.error).not.toHaveBeenCalled();
     return settings;
   }
+
+  it('should return the default skyux version if logSkyuxVersion is set to false', () => {
+    const version = 'custom-skyux-version-npm3';
+    const settings = setupPackageJson(
+      {
+        spec: version
+      },
+      {
+        logSkyuxVersion: false
+      });
+    expect(settings.skyuxVersion).toEqual('');
+  });
+
+  it('should return the default skyux version if logSkyuxVersion is set to `false`', () => {
+    const version = 'custom-skyux-version-npm3';
+    const settings = setupPackageJson(
+      {
+        spec: version
+      },
+      {
+        logSkyuxVersion: 'false'
+      });
+    expect(settings.skyuxVersion).toEqual('');
+  });
 
   it('should read the skyux version if it is installed (npm < 5)', () => {
     const version = 'custom-skyux-version-npm3';


### PR DESCRIPTION
Create property to allow users to ignore SkyUX version if none is needed, or if SkyUX does not exist. 