### PR TITLE
Changed to async/await just for file upload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.0 (2020-08-18)
+
+- Updated the `deploy` command to upload assets in series instead of parallel. [#71](https://github.com/blackbaud/skyux-deploy/pull/71)
+
 # 1.7.4 (2020-08-05)
 
 - Fixed the `deploy` command to correctly exclude directories, even if they contain dots. [#70](https://github.com/blackbaud/skyux-deploy/pull/70)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.8.0 (2020-08-18)
+# 1.8.0 (2020-08-19)
 
 - Updated the `deploy` command to upload assets in series instead of parallel. [#71](https://github.com/blackbaud/skyux-deploy/pull/71)
 

--- a/lib/azure.js
+++ b/lib/azure.js
@@ -11,7 +11,7 @@ const utils = require('./utils');
  * @param {Object} settings
  * @returns {Function} promise
  */
-function registerAssetsToBlob(settings, assets) {
+async function registerAssetsToBlob(settings, assets) {
   const blob = azure.createBlobService(
     settings.azureStorageAccount,
     settings.azureStorageAccessKey
@@ -49,12 +49,20 @@ function registerAssetsToBlob(settings, assets) {
       fnReject('Assets are required.');
     }
 
-    blob.createContainerIfNotExists(settings.name, acl, (error) => {
+    blob.createContainerIfNotExists(settings.name, acl, async (error) => {
       utils.rejectIfError(fnReject, error);
-      Promise.all(assets.map(insert)).then(() => {
+
+      try {
+        for (let i = 0; i < assets.length; i++) {
+          await insert(assets[i]);
+        }
+
         logger.info('SPA %s registered in blob storage.', settings.name);
         fnResolve();
-      }, fnReject);
+      } catch (err) {
+        logger.error(err);
+        fnReject(err);
+      }
     });
   });
 }

--- a/lib/azure.js
+++ b/lib/azure.js
@@ -11,7 +11,7 @@ const utils = require('./utils');
  * @param {Object} settings
  * @returns {Function} promise
  */
-async function registerAssetsToBlob(settings, assets) {
+function registerAssetsToBlob(settings, assets) {
   const blob = azure.createBlobService(
     settings.azureStorageAccount,
     settings.azureStorageAccessKey

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-deploy",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-deploy",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "Deployment package for skyux apps",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Because I was using `Promise.all`, each asset we were uploading was getting allocated a buffer in the `azure-storage` library at once.

We've started to see for very large projects, a Buffer.alloc error because of this.

Uploading the assets are still asynchronous, but now run in series using the `async/await` pattern instead of in parallel with `Promise.all`.

**Edit**

I should add I tested this against one such repo that kept failing and this change allowed it to pass.