### PR TITLE
Remove asset filename hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ All of the following options are required and overridable via the CLI.  For exam
 | `azureStorageAccessKey` | `null`  |
 | `azureStorageTableName` | "spa"   |
 | `isStaticClient`        | `false` |
+| `hasFileNames`          | `true`  |
 
 `null` values are typically supplied by the CI process.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ All of the following options are required and overridable via the CLI.  For exam
 | `azureStorageAccessKey` | `null`  |
 | `azureStorageTableName` | "spa"   |
 | `isStaticClient`        | `false` |
-| `hasFileNames`          | `true`  |
+| `hashFileNames`         | `true`  |
 
 `null` values are typically supplied by the CI process.

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -110,14 +110,13 @@ const formatAssets = (includeContent, isStaticClient, asset) => {
   const assetPath = path.join(assetPathRoot, asset.name);
   const stats = fs.statSync(assetPath);
   const content = fs.readFileSync(assetPath, readOptions);
-  const hash = getHash(content, 'md5', 'hex');
 
   let name;
 
   if (isStaticClient) {
     name = asset.version + '/' + parsed.base;
   } else {
-    name = parsed.name + '.' + hash + parsed.ext;
+    name = parsed.name + '.' + parsed.ext;
   }
 
   const props = {

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -70,7 +70,7 @@ const getStaticAssets = (includeContent, isStaticClient, version) => glob
  * @param {boolean} isStaticClient
  * @returns {Array} assets
  */
-const getDistAssets = (includeContent, isStaticClient, version) => {
+const getDistAssets = (includeContent, isStaticClient, version, hashFileNames) => {
   let metadataPath = path.join(dist, 'metadata.json');
 
   if (isStaticClient) {
@@ -90,7 +90,7 @@ const getDistAssets = (includeContent, isStaticClient, version) => {
   if (fs.existsSync(metadataPath)) {
     const metadata = require(metadataPath);
     return metadata.map((asset) =>
-      formatAssets(includeContent, isStaticClient, asset));
+      formatAssets(includeContent, isStaticClient, asset, hashFileNames));
   }
 
   return [];
@@ -104,7 +104,7 @@ const getDistAssets = (includeContent, isStaticClient, version) => {
  * @param {object} asset
  * @returns {object} asset
  */
-const formatAssets = (includeContent, isStaticClient, asset) => {
+const formatAssets = (includeContent, isStaticClient, asset, hashFileNames = true) => {
   const parsed = path.parse(asset.name);
   const assetPathRoot = isStaticClient ? bundles : dist;
   const assetPath = path.join(assetPathRoot, asset.name);
@@ -116,7 +116,7 @@ const formatAssets = (includeContent, isStaticClient, asset) => {
   if (isStaticClient) {
     name = asset.version + '/' + parsed.base;
   } else {
-    name = parsed.name + '.' + parsed.ext;
+    name = (hashFileNames) ? `${parsed.name}.${getHash(content, 'md5', 'hex')}${parsed.ext}` : asset.name;
   }
 
   const props = {

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -102,6 +102,7 @@ const getDistAssets = (includeContent, isStaticClient, version, hashFileNames) =
  * @param {boolean} includeContent
  * @param {boolean} isStaticClient
  * @param {object} asset
+ * @param {boolean} hashFileNames
  * @returns {object} asset
  */
 const formatAssets = (includeContent, isStaticClient, asset, hashFileNames = true) => {
@@ -110,13 +111,14 @@ const formatAssets = (includeContent, isStaticClient, asset, hashFileNames = tru
   const assetPath = path.join(assetPathRoot, asset.name);
   const stats = fs.statSync(assetPath);
   const content = fs.readFileSync(assetPath, readOptions);
+  const hash = getHash(content, 'md5', 'hex');
 
   let name;
 
   if (isStaticClient) {
     name = asset.version + '/' + parsed.base;
   } else {
-    name = (hashFileNames) ? `${parsed.name}.${getHash(content, 'md5', 'hex')}${parsed.ext}` : asset.name;
+    name = (hashFileNames) ? `${parsed.name}.${hash}${parsed.ext}` : asset.name;
   }
 
   const props = {

--- a/lib/deploy-spa.js
+++ b/lib/deploy-spa.js
@@ -7,7 +7,8 @@ async function deploy(settings) {
   const assetsWithoutContent = assets.getDistAssets(
     false,
     settings.isStaticClient,
-    settings.version
+    settings.version,
+    settings.hashFileNames
   );
 
   const spa = {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -17,7 +17,8 @@ module.exports = (settings) => {
     const assetsCombined = assets.getDistAssets(
       true,
       settings.isStaticClient,
-      settings.version
+      settings.version,
+      settings.hashFileNames
     ).concat(
       assets.getEmittedAssets(
         settings.isStaticClient,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -36,7 +36,8 @@ function getSettings(argv = {}) {
     packageConfig: packageConfig,
     skyuxConfig: skyuxConfig,
     azureStorageTableName: 'spa',
-    isStaticClient: false
+    isStaticClient: false,
+    hashFileNames: true
   };
 
   // Merges in all packageConfig, really only care about name + version

--- a/test/lib-settings.spec.js
+++ b/test/lib-settings.spec.js
@@ -61,4 +61,14 @@ describe('skyux-deploy lib settings', () => {
     expect(settings.name).toEqual('custom-name2');
     expect(settings.version).toEqual('');
   });
+
+  it('should support disabling hashed file names', () => {
+    const lib = require('../lib/settings');
+    const settings = lib.getSettings({
+      name: 'foobar',
+      hashFileNames: false
+    });
+
+    expect(settings.hashFileNames).toEqual(false);
+  });
 });


### PR DESCRIPTION
We are hashing the asset file names, but Angular CLI already does this. For scripts that point to initial chunks this isn't a problem since the files are embedded directly on the page. For non-initial, or "lazyloaded" chunks, Angular won't be able to find the script if its name has been altered.

To disable hashing, add the following argument: `--no-hash-file-names`