### PR TITLE
Add support for root element tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ All of the following options are required and overridable via the CLI.  For exam
 | `azureStorageTableName` | "spa"   |
 | `isStaticClient`        | `false` |
 | `hashFileNames`         | `true`  |
+! `rootElementTagName` | `null`  |
 
 `null` values are typically supplied by the CI process.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ All of the following options are required and overridable via the CLI.  For exam
 | `azureStorageTableName` | "spa"   |
 | `isStaticClient`        | `false` |
 | `hashFileNames`         | `true`  |
-! `rootElementTagName` | `null`  |
+! `rootElementTagName`    | `null`  |
 
 `null` values are typically supplied by the CI process.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ All of the following options are required and overridable via the CLI.  For exam
 | `azureStorageTableName` | "spa"   |
 | `isStaticClient`        | `false` |
 | `hashFileNames`         | `true`  |
-! `rootElementTagName`    | `null`  |
+| `rootElementTagName`    | `null`  |
 
 `null` values are typically supplied by the CI process.

--- a/lib/deploy-spa.js
+++ b/lib/deploy-spa.js
@@ -18,6 +18,10 @@ async function deploy(settings) {
     sky_ux_config: settings.skyuxConfig
   };
 
+  if (settings.rootElementTagName) {
+    spa.rootElementTagName = settings.rootElementTagName;
+  }
+
   return await portal.deploySpa(settings.azureStorageAccessKey, spa, settings.version);
 }
 

--- a/lib/deploy-spa.js
+++ b/lib/deploy-spa.js
@@ -19,7 +19,7 @@ async function deploy(settings) {
   };
 
   if (settings.rootElementTagName) {
-    spa.rootElementTagName = settings.rootElementTagName;
+    spa.root_element_tag_name = settings.rootElementTagName;
   }
 
   return await portal.deploySpa(settings.azureStorageAccessKey, spa, settings.version);

--- a/test/lib-deploy-spa.spec.js
+++ b/test/lib-deploy-spa.spec.js
@@ -70,4 +70,23 @@ describe('skyux-deploy lib deploy SPA', () => {
     );
   });
 
+  it('should deploy SPA with root element tag name', async () => {
+    await lib({
+      azureStorageAccessKey: 'abc',
+      name: 'custom-name2',
+      version: 'custom-version2',
+      rootElementTagName: 'app-root',
+      skyuxConfig: { test1: true },
+      packageConfig: { test2: true }
+    });
+
+    const actualTagName = portalMock.deploySpa
+      .calls
+      .mostRecent()
+      .args[1]
+      .rootElementTagName;
+
+    expect(actualTagName).toEqual('app-root');
+  });
+
 });

--- a/test/lib-deploy-spa.spec.js
+++ b/test/lib-deploy-spa.spec.js
@@ -84,7 +84,7 @@ describe('skyux-deploy lib deploy SPA', () => {
       .calls
       .mostRecent()
       .args[1]
-      .rootElementTagName;
+      .root_element_tag_name;
 
     expect(actualTagName).toEqual('app-root');
   });

--- a/test/lib-settings.spec.js
+++ b/test/lib-settings.spec.js
@@ -71,4 +71,14 @@ describe('skyux-deploy lib settings', () => {
 
     expect(settings.hashFileNames).toEqual(false);
   });
+
+  it('should support setting the root element tag name', () => {
+    const lib = require('../lib/settings');
+    const settings = lib.getSettings({
+      name: 'foobar',
+      rootElementTagName: 'app-root'
+    });
+
+    expect(settings.rootElementTagName).toEqual('app-root');
+  });
 });


### PR DESCRIPTION
To save the app's root element tag name (such as `app-root`), do:
```
skyux deploy --rootElementTagName app-root
```